### PR TITLE
Chapter 09: Test Doubles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All Notable changes to `zeravcic\phpunit-de` project will be documented in this 
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.2.0] - 2017-01-03
+### Added
+- tests/chapter09/AbstractClass.php
+- test/chapter09/AbstractClassTest.php
+- test/chapter09/AbstractTrait.php
+- test/chapter09/Example.php
+- test/chapter09/Example2Test.php
+- test/chapter09/ExampleTest.php
+- test/chapter09/Foo2Test.php
+- test/chapter09/Foo3Test.php
+- test/chapter09/FooTest.php
+- test/chapter09/GoogleTest.php
+- test/chapter09/Observer.php
+- test/chapter09/SomeClass.php
+- test/chapter09/Stub2Test.php
+- test/chapter09/Stub3Test.php
+- test/chapter09/Stub4Test.php
+- test/chapter09/Stub5Test.php
+- test/chapter09/Stub6Test.php
+- test/chapter09/Stub7Test.php
+- test/chapter09/Stub8Test.php
+- test/chapter09/Stub9Test.php
+- test/chapter09/StubTest.php
+- test/chapter09/Subject.php
+- test/chapter09/Subject2Test.php
+- test/chapter09/Subject3Test.php
+- test/chapter09/Subject4Test.php
+- test/chapter09/SubjectTest.php
+- test/chapter09/TraitClassTest.php
+
+### Changed
+- composer.json
+
 ## [0.1.1] - 2017-01-01
 ### Changed
 - README.md
@@ -70,8 +103,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - .gitignore
 - .travis.yml
 - CHANGELOG.md
+- composer.json
 - phpunit.xml
 - README.md
 
+[0.2.0]: https://github.com/zeravcic/phpunit-de/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/zeravcic/phpunit-de/compare/v0.1.0...v0.1.1
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "php" : "~5.5|~7.0"
   },
   "require-dev": {
-    "phpunit/phpunit" : "5.*"
+    "phpunit/phpunit" : "5.*",
+    "mikey179/vfsStream": "^1.6"
   },
   "autoload": {
     "psr-4": {

--- a/tests/chapter09/AbstractClass.php
+++ b/tests/chapter09/AbstractClass.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+namespace Zeravcic\PhpUnit_De\Tests\chapter09;
+
+/**
+ * Class AbstractClass
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ */
+abstract class AbstractClass
+{
+    public function concreteMethod()
+    {
+        return $this->abstractMethod();
+    }
+
+    public abstract function abstractMethod();
+}
+

--- a/tests/chapter09/AbstractClassTest.php
+++ b/tests/chapter09/AbstractClassTest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+namespace Zeravcic\PhpUnit_De\Tests\chapter09;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class AbstractClassTest
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ */
+class AbstractClassTest extends TestCase
+{
+    public function testConcreteMethod()
+    {
+        $stub = $this->getMockForAbstractClass(AbstractClass::class);
+
+        $stub->expects($this->any())
+            ->method('abstractMethod')
+            ->will($this->returnValue(true));
+
+        $this->assertTrue($stub->concreteMethod());
+    }
+}

--- a/tests/chapter09/AbstractTrait.php
+++ b/tests/chapter09/AbstractTrait.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+namespace Zeravcic\PhpUnit_De\Tests\chapter09;
+
+/**
+ * Class AbstractTrait
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ */
+trait AbstractTrait
+{
+    public function concreteMethod()
+    {
+        return $this->abstractMethod();
+    }
+
+    public abstract function abstractMethod();
+}

--- a/tests/chapter09/Example.php
+++ b/tests/chapter09/Example.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+namespace Zeravcic\PhpUnit_De\Tests\chapter09;
+
+/**
+ * Class Example
+ *
+ * COMPOSER MANDATORY CODE:
+ * {
+ *  "require-dev": {
+ *      "phpunit/phpunit": "~4.6",
+ *      "mikey179/vfsStream": "~1"
+ *  }
+ * }
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ */
+class Example
+{
+    protected $id;
+    protected $directory;
+
+    public function __construct($id)
+    {
+        $this->id = $id;
+    }
+
+    public function setDirectory($directory)
+    {
+        $this->directory = $directory . DIRECTORY_SEPARATOR . $this->id;
+
+        if (!file_exists($this->directory)) {
+            mkdir($this->directory, 0700, true);
+        }
+    }
+}

--- a/tests/chapter09/Example2Test.php
+++ b/tests/chapter09/Example2Test.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+namespace Zeravcic\PhpUnit_De\Tests\chapter09;
+
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+use org\bovigo\vfs\vfsStreamWrapper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class Example2Test
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ */
+class Example2Test extends TestCase
+{
+    public function setUp()
+    {
+        vfsStreamWrapper::register();
+        vfsStreamWrapper::setRoot(new vfsStreamDirectory('exampleDir'));
+    }
+
+    public function testDirectoryIsCreated()
+    {
+        $example = new Example('id');
+        $this->assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
+
+        $example->setDirectory(vfsStream::url('exampleDir'));
+        $this->assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
+    }
+}

--- a/tests/chapter09/ExampleTest.php
+++ b/tests/chapter09/ExampleTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+namespace Zeravcic\PhpUnit_De\Tests\chapter09;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class ExampleTest
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ */
+class ExampleTest extends TestCase
+{
+    protected function setUp()
+    {
+        if (file_exists(dirname(__FILE__) . '/id')) {
+            rmdir(dirname(__FILE__) . '/id');
+        }
+    }
+
+    public function testDirectoryIsCreated()
+    {
+        $example = new Example('id');
+        $this->assertFalse(file_exists(dirname(__FILE__) . '/id'));
+
+        $example->setDirectory(dirname(__FILE__));
+        $this->assertTrue(file_exists(dirname(__FILE__) . '/id'));
+    }
+
+    protected function tearDown()
+    {
+        if (file_exists(dirname(__FILE__) . '/id')) {
+            rmdir(dirname(__FILE__) . '/id');
+        }
+    }
+}

--- a/tests/chapter09/Foo2Test.php
+++ b/tests/chapter09/Foo2Test.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+namespace Zeravcic\PhpUnit_De\Tests\chapter09;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class Foo2Test
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ */
+class Foo2Test extends TestCase
+{
+    public function testIdenticalObjectPassed()
+    {
+        $expectedObject = new \stdClass;
+
+        $mock = $this->getMockBuilder(\stdClass::class)
+            ->setMethods(['foo'])
+            ->getMock();
+
+        $mock->expects($this->once())
+            ->method('foo')
+            ->with($this->identicalTo($expectedObject));
+
+        $mock->foo($expectedObject);
+    }
+}

--- a/tests/chapter09/Foo3Test.php
+++ b/tests/chapter09/Foo3Test.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+namespace Zeravcic\PhpUnit_De\Tests\chapter09;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class Foo3Test
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ */
+class Foo3Test extends TestCase
+{
+    public function testIdenticalObjectPassed()
+    {
+        $cloneArguments = true;
+
+        $mock = $this->getMockBuilder(stdClass::class)
+            ->enableArgumentCloning()
+            ->getMock();
+
+        // now your mock clones parameters so the identicalTo constraint
+        // will fail.
+    }
+}

--- a/tests/chapter09/FooTest.php
+++ b/tests/chapter09/FooTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+namespace Zeravcic\PhpUnit_De\Tests\chapter09;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class FooTest
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ */
+class FooTest extends TestCase
+{
+    public function testFunctionCalledTwoTimesWithSpecificArguments()
+    {
+        $mock = $this->getMockBuilder(stdClass::class)
+            ->setMethods(['set'])
+            ->getMock();
+
+        $mock->expects($this->exactly(3))
+            ->method('set')
+            ->withConsecutive(
+                [$this->equalTo('foo'), $this->greaterThan(0)],
+                [$this->equalTo('bar'), $this->greaterThan(0)]
+            );
+
+        $mock->set('foo', 21);
+        $mock->set('bar', 48);
+    }
+}

--- a/tests/chapter09/GoogleTest.php
+++ b/tests/chapter09/GoogleTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+namespace Zeravcic\PhpUnit_De\Tests\chapter09;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class GoogleTest
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ */
+class GoogleTest extends TestCase
+{
+    public function testSearch()
+    {
+        $googleSearch = $this->getMockFromWsdl(
+            'GoogleSearch.wsdl', 'GoogleSearch'
+        );
+
+        $directoryCategory = new stdClass;
+        $directoryCategory->fullViewableName = '';
+        $directoryCategory->specialEncoding = '';
+
+        $element = new stdClass;
+        $element->summary = '';
+        $element->URL = 'https://phpunit.de/';
+        $element->snippet = '...';
+        $element->title = '<b>PHPUnit</b>';
+        $element->cachedSize = '11k';
+        $element->relatedInformationPresent = true;
+        $element->hostName = 'phpunit.de';
+        $element->directoryCategory = $directoryCategory;
+        $element->directoryTitle = '';
+
+        $result = new stdClass;
+        $result->documentFiltering = false;
+        $result->searchComments = '';
+        $result->estimatedTotalResultsCount = 3.9000;
+        $result->estimateIsExact = false;
+        $result->resultElements = [$element];
+        $result->searchQuery = 'PHPUnit';
+        $result->startIndex = 1;
+        $result->endIndex = 1;
+        $result->searchTips = '';
+        $result->directoryCategories = [];
+        $result->searchTime = 0.248822;
+
+        $googleSearch->expects($this->any())
+            ->method('doGoogleSearch')
+            ->will($this->returnValue($result));
+
+        /**
+         * $googleSearch->doGoogleSearch() will now return a stubbed result and
+         * the web service's doGoogleSearch() method will not be invoked.
+         */
+        $this->assertEquals(
+            $result,
+            $googleSearch->doGoogleSearch(
+                '00000000000000000000000000000000',
+                'PHPUnit',
+                0,
+                1,
+                false,
+                '',
+                false,
+                '',
+                '',
+                ''
+            )
+        );
+    }
+}

--- a/tests/chapter09/Observer.php
+++ b/tests/chapter09/Observer.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+namespace Zeravcic\PhpUnit_De\Tests\chapter09;
+
+/**
+ * Class Observer
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ */
+class Observer
+{
+    public function update($argument)
+    {
+        // Do something.
+    }
+
+    public function reportError($errorCode, $errorMessage, Subject $subject)
+    {
+        // Do something
+    }
+
+    // Other methods.
+}

--- a/tests/chapter09/SomeClass.php
+++ b/tests/chapter09/SomeClass.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+namespace Zeravcic\PhpUnit_De\Tests\chapter09;
+
+// $loader = require __DIR__ . '/../../../../../vendor/autoload.php';
+
+class SomeClass
+{
+    public function doSomething()
+    {
+        // Do something.
+    }
+}

--- a/tests/chapter09/Stub2Test.php
+++ b/tests/chapter09/Stub2Test.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+namespace Zeravcic\PhpUnit_De\Tests\chapter09;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class Stub2Test
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ */
+class Stub2Test extends TestCase
+{
+    public function testStub()
+    {
+        // Create a stub for the SomeClass class.
+        $stub = $this->getMockBuilder(SomeClass::class)
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->disallowMockingUnknownTypes()
+            ->getMock();
+
+        // Configure the stub.
+        $stub->method('doSomething')
+            ->willReturn('foo');
+
+        // Calling $stub->doSomething() will now return
+        // 'foo'.
+        $this->assertEquals('foo', $stub->doSomething());
+    }
+}

--- a/tests/chapter09/Stub3Test.php
+++ b/tests/chapter09/Stub3Test.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+namespace Zeravcic\PhpUnit_De\Tests\chapter09;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class Stub3Test
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ */
+class Stub3Test extends TestCase
+{
+    public function testReturnArgumentStub()
+    {
+        // Create a stub for the SomeClass class.
+        $stub = $this->createMock(SomeClass::class);
+
+        // Configure the stub.
+        $stub->method('doSomething')
+            ->will($this->returnArgument(0));
+
+        // $stub->doSomething('foo') returns 'foo'
+        $this->assertEquals('foo', $stub->doSomething('foo'));
+
+        // $stub->doSomething('bar') returns 'bar'
+        $this->assertEquals('bar', $stub->doSomething('bar'));
+    }
+}

--- a/tests/chapter09/Stub4Test.php
+++ b/tests/chapter09/Stub4Test.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+namespace Zeravcic\PhpUnit_De\Tests\chapter09;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class Stub4Test
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ */
+class Stub4Test extends TestCase
+{
+    public function testReturnArgumentStub()
+    {
+        // Create a stub for the SomeClass class.
+        $stub = $this->createMock(SomeClass::class);
+
+        // Configure the stub.
+        $stub->method('doSomething')
+            ->will($this->returnArgument(0));
+
+        // $stub->doSomething('foo') returns 'foo'
+        $this->assertEquals('foo', $stub->doSomething('foo'));
+
+        // $stub->doSomething('bar') returns 'bar'
+        $this->assertEquals('bar', $stub->doSomething('bar'));
+    }
+}

--- a/tests/chapter09/Stub5Test.php
+++ b/tests/chapter09/Stub5Test.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+namespace Zeravcic\PhpUnit_De\Tests\chapter09;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class Stub5Test
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ */
+class Stub5Test extends TestCase
+{
+    public function testReturnSelf()
+    {
+        // Create a stub for the SomeClass class.
+        $stub = $this->createMock(SomeClass::class);
+
+        // Configure the stub.
+        $stub->method('doSomething')
+            ->will($this->returnSelf());
+
+        // $stub->doSomething() returns $stub
+        $this->assertSame($stub, $stub->doSomething());
+    }
+}

--- a/tests/chapter09/Stub6Test.php
+++ b/tests/chapter09/Stub6Test.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+namespace Zeravcic\PhpUnit_De\Tests\chapter09;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class Stub6Test
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ */
+class Stub6Test extends TestCase
+{
+    public function testReturnValueMapStub()
+    {
+        // Create a stub for the SomeClass class.
+        $stub = $this->createMock(SomeClass::class);
+
+        // Create a map of arguments to return values.
+        $map = [
+            ['a', 'b', 'c', 'd'],
+            ['e', 'f', 'g', 'h']
+        ];
+
+        // Configure the stub.
+        $stub->method('doSomething')
+            ->will($this->returnValueMap($map));
+
+        // $stub->doSomething() returns different values depending on
+        // the provided arguments.
+        $this->assertEquals('d', $stub->doSomething('a', 'b', 'c'));
+        $this->assertEquals('h', $stub->doSomething('e', 'f', 'g'));
+    }
+}

--- a/tests/chapter09/Stub7Test.php
+++ b/tests/chapter09/Stub7Test.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+namespace Zeravcic\PhpUnit_De\Tests\chapter09;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class Stub7Test
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ */
+class Stub7Test extends TestCase
+{
+    public function testReturnCallbackStub()
+    {
+        // Create a stub for the SomeClass class.
+        $stub = $this->createMock(SomeClass::class);
+
+        // Configure the stub.
+        $stub->method('doSomething')
+            ->will($this->returnCallback('str_rot13'));
+
+        // $stub->doSomething($argument) returns str_rot13($argument)
+        $this->assertEquals('fbzrguvat', $stub->doSomething('something'));
+    }
+}

--- a/tests/chapter09/Stub8Test.php
+++ b/tests/chapter09/Stub8Test.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+namespace Zeravcic\PhpUnit_De\Tests\chapter09;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class Stub8Test
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ */
+class Stub8Test extends TestCase
+{
+    public function testOnConsecutiveCallsStub()
+    {
+        // Create a stub for the SomeClass class.
+        $stub = $this->createMock(SomeClass::class);
+
+        // Configure the stub.
+        $stub->method('doSomething')
+            ->will($this->onConsecutiveCalls(2, 3, 5, 7));
+
+        // $stub->doSomething() returns a different value each time
+        $this->assertEquals(2, $stub->doSomething());
+        $this->assertEquals(3, $stub->doSomething());
+        $this->assertEquals(5, $stub->doSomething());
+    }
+}

--- a/tests/chapter09/Stub9Test.php
+++ b/tests/chapter09/Stub9Test.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+namespace Zeravcic\PhpUnit_De\Tests\chapter09;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class Stub9Test
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ */
+class Stub9Test extends TestCase
+{
+    public function testThrowExceptionStub()
+    {
+        // Create a stub for the SomeClass class.
+        $stub = $this->createMock(SomeClass::class);
+
+        // Configure the stub.
+        $stub->method('doSomething')
+            ->will($this->throwException(new \Exception));
+
+        // $stub->doSomething() throws Exception
+        $stub->doSomething();
+    }
+}

--- a/tests/chapter09/StubTest.php
+++ b/tests/chapter09/StubTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+namespace Zeravcic\PhpUnit_De\Tests\chapter09;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class StubTest
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ */
+class StubTest extends TestCase
+{
+    public function testStub()
+    {
+        // Create a stub for the SomeClass class.
+        $stub = $this->createMock(SomeClass::class);
+
+        // Configure the stub.
+        $stub->method('doSomething')
+            ->willReturn('foo');
+
+        // Calling $stub->doSomething() will now return
+        // 'foo'.
+        $this->assertEquals('foo', $stub->doSomething());
+    }
+}

--- a/tests/chapter09/Subject.php
+++ b/tests/chapter09/Subject.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+namespace Zeravcic\PhpUnit_De\Tests\chapter09;
+
+/**
+ * Class Subject
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ */
+class Subject
+{
+    protected $observers = [];
+    protected $name;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function attach(Observer $observer)
+    {
+        $this->observers[] = $observer;
+    }
+
+    public function doSomething()
+    {
+        // Do something.
+        // ...
+
+        // Notify observers that we did something.
+        $this->notify('something');
+    }
+
+    public function doSomethingBad()
+    {
+        foreach ($this->observers as $observer) {
+            $observer->reportError(42, 'Something bad happened', $this);
+        }
+    }
+
+    protected function notify($argument)
+    {
+        foreach ($this->observers as $observer) {
+            $observer->update($argument);
+        }
+    }
+
+    // Other methods.
+}

--- a/tests/chapter09/Subject2Test.php
+++ b/tests/chapter09/Subject2Test.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+namespace Zeravcic\PhpUnit_De\Tests\chapter09;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class Subject2Test
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ */
+class Subject2Test extends TestCase
+{
+    public function testErrorReported()
+    {
+        // Create a mock for the Observer class, mocking the
+        // reportError() method
+        $observer = $this->getMockBuilder(Observer::class)
+            ->setMethods(['reportError'])
+            ->getMock();
+
+        $observer->expects($this->once())
+            ->method('reportError')
+            ->with(
+                $this->greaterThan(0),
+                $this->stringContains('Something'),
+                $this->anything()
+            );
+
+        $subject = new Subject('My subject');
+        $subject->attach($observer);
+
+        // The doSomethingBad() method should report an error to the observer
+        // via the reportError() method
+        $subject->doSomethingBad();
+    }
+}

--- a/tests/chapter09/Subject3Test.php
+++ b/tests/chapter09/Subject3Test.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+namespace Zeravcic\PhpUnit_De\Tests\chapter09;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class Subject3Test
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ */
+class Subject3Test extends TestCase
+{
+    public function testErrorReported()
+    {
+        // Create a mock for the Observer class, mocking the
+        // reportError() method
+        $observer = $this->getMockBuilder(Observer::class)
+            ->setMethods(['reportError'])
+            ->getMock();
+
+        $observer->expects($this->once())
+            ->method('reportError')
+            ->with($this->greaterThan(0),
+                $this->stringContains('Something'),
+                $this->callback(function($subject){
+                    return is_callable([$subject, 'getName']) &&
+                        $subject->getName() == 'My subject';
+                }));
+
+        $subject = new Subject('My subject');
+        $subject->attach($observer);
+
+        // The doSomethingBad() method should report an error to the observer
+        // via the reportError() method
+        $subject->doSomethingBad();
+    }
+}

--- a/tests/chapter09/Subject4Test.php
+++ b/tests/chapter09/Subject4Test.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+namespace Zeravcic\PhpUnit_De\Tests\chapter09;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class Subject4Test
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ */
+class Subject4Test extends TestCase
+{
+    public function testObserversAreUpdated()
+    {
+        $subject = new Subject('My subject');
+
+        // Create a prophecy for the Observer class.
+        $observer = $this->prophesize(Observer::class);
+
+        // Set up the expectation for the update() method
+        // to be called only once and with the string 'something'
+        // as its parameter.
+        $observer->update('something')->shouldBeCalled();
+
+        // Reveal the prophecy and attach the mock object
+        // to the Subject.
+        $subject->attach($observer->reveal());
+
+        // Call the doSomething() method on the $subject object
+        // which we expect to call the mocked Observer object's
+        // update() method with the string 'something'.
+        $subject->doSomething();
+    }
+}

--- a/tests/chapter09/SubjectTest.php
+++ b/tests/chapter09/SubjectTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+namespace Zeravcic\PhpUnit_De\Tests\chapter09;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class SubjectTest
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ */
+class SubjectTest extends TestCase
+{
+    public function testObserversAreUpdated()
+    {
+        // Create a mock for the Observer class,
+        // only mock the update() method.
+        $observer = $this->getMockBuilder(Observer::class)
+            ->setMethods(['update'])
+            ->getMock();
+
+        // Set up the expectation for the update() method
+        // to be called only once and with the string 'something'
+        // as its parameter.
+        $observer->expects($this->once())
+            ->method('update')
+            ->with($this->equalTo('something'));
+
+        // Create a Subject object and attach the mocked
+        // Observer object to it.
+        $subject = new Subject('My subject');
+        $subject->attach($observer);
+
+        // Call the doSomething() method on the $subject object
+        // which we expect to call the mocked Observer object's
+        // update() method with the string 'something'.
+        $subject->doSomething();
+    }
+}

--- a/tests/chapter09/TraitClassTest.php
+++ b/tests/chapter09/TraitClassTest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+namespace Zeravcic\PhpUnit_De\Tests\chapter09;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class TraitClassTest
+ *
+ * @package Zeravcic\PhpUnit_De\Tests\chapter09
+ */
+class TraitClassTest extends TestCase
+{
+    public function testConcreteMethod()
+    {
+        $mock = $this->getMockForTrait(AbstractTrait::class);
+
+        $mock->expects($this->any())
+            ->method('abstractMethod')
+            ->will($this->returnValue(true));
+
+        $this->assertTrue($mock->concreteMethod());
+    }
+}


### PR DESCRIPTION
Sometimes it is just plain hard to test the system under test (SUT)
because it depends on other components that cannot be used in the test
environment. This could be because they aren't available, they will not
return the results needed for the test or because executing them would
have undesirable side effects. In other cases, our test strategy
requires us to have more control or visibility of the internal behavior
of the SUT.

When we are writing a test in which we cannot (or chose not to) use a
real depended-on component (DOC), we can replace it with a Test Double.
The Test Double doesn't have to behave exactly like the real DOC; it
merely has to provide the same API as the real one so that the SUT
thinks it is the real one!